### PR TITLE
Fix: convert endl to std::endl and string to std::string

### DIFF
--- a/help.cpp
+++ b/help.cpp
@@ -2,11 +2,11 @@
 
 void help() {
   std::cout<<"***console-calc***\n";
-  std::cout<<"This calculator uses endless loop to read the equations"<<endl;
+  std::cout<<"This calculator uses endless loop to read the equations\n";
   std::cout<<"console-calc\t\t\tenables CLI mode, which allows to calculate multiple equations in a loop\n\n";
   std::cout<<"\n\nUsage:\n";
-  std::cout<<"It is capable of doing basic equations as addition, substraction, division and multiplication"<<endl;
-  std::cout<<"console-calc \"(2+2)*2\"\tprints result of specified equation\n"<<endl;
+  std::cout<<"It is capable of doing basic equations as addition, substraction, division and multiplication\n";
+  std::cout<<"console-calc \"(2+2)*2\"\tprints result of specified equation\n";
   std::cout<<"You can learn more or submit issues on Gitbuh:\n";
   std::cout<<"https://github.com/danrog303/console-calc";
 }

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char** argv) {
         std::cout << "Type console-calc --help to learn how to use console-calc.";
     }
     // help message (-h)
-    else if(argc == 2 && (string(argv[1]) == "--help" || string(argv[1]) == "-h")) {
+    else if(argc == 2 && (std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h")) {
         help();
     }
     // cli mode (no arguments)


### PR DESCRIPTION
Fix program not compiling by changing all **string** usages to **std::string** and **endl** to **std::endl**.